### PR TITLE
Added tags for solar heating

### DIFF
--- a/custom_components/orca/config.yml
+++ b/custom_components/orca/config.yml
@@ -184,3 +184,24 @@
   name_si: "TC Črpalka sanitarne vode"
   description: "Poganja sanitarno vodo"
   type: "boolean"
+
+
+## Solar collectors ##
+2_SOLAR_VKLOP:
+  name: "HP Solar Heating"
+  name_si: "TC Sončna energija"
+  description: "Ali je ogrevanje sanitarne vode s sončno energijo vklopljeno"
+  type: "boolean"
+
+2_Vklop_C3:
+  name: "HP Solar Pump"
+  name_si: "TC Črpalka sončne energije"
+  description: "Poganja vodo skozi sončne kolektorje"
+  type: "boolean"
+
+2_Poti5:
+  name: "HP Solar Collector Temperature"
+  name_si: "TC Temperatura sončnih kolektorjev"
+  description: "Temperatura senzorja na sončnih kolektorjih"
+  type: "temperature"
+  unit: "°C"


### PR DESCRIPTION
Description
This pull request adds new entities for integrating a solar heating system into Home Assistant. These entities will support monitoring and controlling solar water heating, pump operation, and collector temperature.

New entities:

2_SOLAR_VKLOP: Boolean tag indicating if solar water heating is enabled.
2_Vklop_C3: Boolean tag representing solar pump activity.
2_Poti5: Temperature tag capturing solar collector sensor readings (°C).

Finally had some sunny weather over the weekend to check the functionality
