### PR TITLE
Safety fix for solar toggle and a tool

### DIFF
--- a/custom_components/orca/config.yml
+++ b/custom_components/orca/config.yml
@@ -24,7 +24,7 @@
     si: "ime ogrevalnega kroga"
   description: ""
   type: "multimode"
-  value_map:  # first three are default names, typically indicate unconfigured circuit
+  value_map: # first three are default names, typically indicate unconfigured circuit
     4: "Heating Circuit 2"
     5: "Heating Circuit 3"
     6: "Direct Circuit 1"
@@ -242,7 +242,6 @@
       max: 9.9
       step: 0.1
   heating_circuit: 1
-
 
 ## Heating loop 2 (Orgrevalni krog 2)
 - tag: MK1_IME(2)
@@ -470,7 +469,6 @@
       max: 9.9
       step: 0.1
   heating_circuit: 2
-
 
 ## Internal sensors ##
 - tag: 2_Temp_Zunanja
@@ -730,7 +728,7 @@
   description: "Ali je ogrevanje sanitarne vode s sončno energijo vklopljeno"
   type: "boolean"
   adjustable:
-    enabled: true
+    enabled: false
   heating_circuit: 3
 
 - tag: 2_Vklop_C3
@@ -755,7 +753,6 @@
   adjustable:
     enabled: false
   heating_circuit: 3
-
 
 ## Buffer tank - zalogovnik, simulated heating circuit 5 ##
 - tag: 2_Temp_Zalog

--- a/development_resources/dump_all/dump_to_file.py
+++ b/development_resources/dump_all/dump_to_file.py
@@ -1,0 +1,31 @@
+from orca_api import OrcaApi
+from datetime import datetime
+
+HARDCODED_HOST_IP = ""  # Set IP here to skip prompt, e.g. "192.168.1.100"
+
+
+def main():
+    host = HARDCODED_HOST_IP or input("Enter device IP address: ").strip()
+
+    orca = OrcaApi(username="admin", password="admin", host=host)
+    orca.initialize()
+
+    # Dump all (prints raw response directly)
+    raw_data = orca.sensor_status_all()
+
+    # Save raw data to file with timestamp
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"development_resources/dump_all/tag_dump_{timestamp}.txt"
+    with open(filename, "w") as f:
+        f.write(raw_data)
+    print(f"Raw data saved to {filename}")
+
+    # fetch one or more (prints raw response directly)
+    # orca.sensor_status_by_tag(["2_Temp_Zunanja", "2_Poti3"])
+
+    # set tag (prints raw response directly)
+    # orca.set_value("2_Max_moc_TC_pri_SV", "38")
+
+
+if __name__ == "__main__":
+    main()

--- a/development_resources/dump_all/orca_api.py
+++ b/development_resources/dump_all/orca_api.py
@@ -25,10 +25,12 @@ class OrcaApi:
         self.fetch_data(url, test=True)
 
     def sensor_status_all(self):
+        raw_data = ""
         for uri in self.generate_uri(self.config.keys()):
             url = f'http://{self.host}{uri}'
-            self.fetch_data(url)
+            raw_data += str(self.fetch_data(url))    
             time.sleep(1)
+        return raw_data
 
     def sensor_status_by_tag(self, fields: list):
         uri = self.generate_uri(fields)[0]
@@ -80,6 +82,7 @@ class OrcaApi:
             print(f'Error while retrieving data. Response: {data_raw}')
     
         print(data_raw)
+        return data_raw
             
     @staticmethod
     def generate_uri(tags: list) -> list:


### PR DESCRIPTION
Commit 1: Remove adjustable solar heating toggle, whitespace cleanup

Removes the adjustable flag from the solar heating toggle. Accidentally turning this off from Home Assistant could cause the solar system to overheat and cause damage. Additionally, with configurable heating circuits in the latest version, it's worth reconsidering whether this entity is needed at all - even as read-only.

Also includes minor auto-formatted whitespace cleanup.

Commit 2: Tool to manually dump tags to file

Adds a script under [dump_all] that fetches all tags from the heat pump and saves the raw response to a timestamped file. No changes to the integration.