### PR TITLE
Fix #30: force_include flag for repurposed physical inputs

### DIFF
--- a/custom_components/orca/config.yml
+++ b/custom_components/orca/config.yml
@@ -852,6 +852,7 @@
   adjustable:
     enabled: false
   heating_circuit: 3
+  force_include: true
 
 ## Buffer tank - zalogovnik, simulated heating circuit 5 ##
 - tag: 2_Temp_Zalog

--- a/custom_components/orca/models.py
+++ b/custom_components/orca/models.py
@@ -1,5 +1,4 @@
 """Pydantic models for Orca integration configuration."""
-
 from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
@@ -42,6 +41,8 @@ class BaseSensor(BaseModel):
     name: LocalizedName
     description: str = ""  # Default empty string if missing
     heating_circuit: int
+    # When True, the entity is always created regardless of circuit detection.
+    force_include: bool = False
     adjustable: AdjustableSettings = Field(default_factory=AdjustableSettings)
 
 

--- a/custom_components/orca/orca_api.py
+++ b/custom_components/orca/orca_api.py
@@ -206,7 +206,10 @@ class OrcaApi:
         final_config = []
 
         for config in config_entries:
-            if config.heating_circuit not in self.available_circuits:
+            if (
+                not config.force_include
+                and config.heating_circuit not in self.available_circuits
+            ):
                 continue
 
             unique_id = config.id


### PR DESCRIPTION
# Fix #30 — Solar collector temperature (`2_Poti5`) dropped in 2.3.x

## Root cause

Circuit detection changed between 2.2.0 and 2.3.x.

**2.2.0** decided a circuit was "available" by checking whether its detection tag was simply *present* in the API results:

```python
3: ["2_Poti5"],
...
if len([t for t in tags if t in results_map]) == len(tags):
    self.available_circuits.append(circuit_id)
```

`2_Poti5` always returns a value when something is wired to that physical input, so circuit 3 was always considered available.

**2.3.x** switched to checking the *value* of a schema tag:

```python
3: ["2_Shema_SOLAR"],
...
if results_map.get(tag) and results_map[tag].value:
    self.available_circuits.append(circuit_id)
```

On installations that **wire an external sensor to the solar collector input (`2_Poti5`) without having the Orca solar package**, `2_Shema_SOLAR` returns `0`/false. Circuit 3 is therefore not added to `available_circuits`, and the per-circuit filter in `_filter_and_rename_circuits` drops **every** circuit-3 entity — including the still-valid `2_Poti5` reading.

This is why it looked mysterious: in a normal install, solar hardware and the solar schema always go together, so they never diverge. The regression only shows up when a physical input is repurposed.

### Reproduction (no hardware needed)

With `2_Shema_SOLAR` = 0 and `2_Poti5` = 37.9:

| Version | `available_circuits` | `2_Poti5` included |
|---|---|---|
| 2.2.0 (presence-based) | `[3]` | ✅ yes |
| 2.3.x (value-based) | `[0, 1]` | ❌ no |

## Fix

Add an optional `force_include: bool = False` field to `BaseSensor`. When set, the entity bypasses circuit detection:

```python
if (
    not config.force_include
    and config.heating_circuit not in self.available_circuits
):
    continue
```

Then set `force_include: true` on the `2_Poti5` entry in `config.yml`.

Because `_get_bulk_values` already skips `-9999` readings, installs with nothing wired to that input still get **no** entity — so this is safe for everyone and simply restores the 2.2.0 behaviour for this one repurposable input.

## Verification

- Richard's case (no solar schema): `2_Poti5` is included again; the meaningless `2_SOLAR_VKLOP` / `2_Vklop_C3` stay excluded (correct — there is no real solar circuit).
- Normal solar install (circuit 3 detected): unchanged, `2_Poti5` still included.
- Install with nothing on the input: `-9999` → still filtered, no phantom entity.
- Full `config.yml` validates against the Pydantic models; both edited files compile.

## Notes for the maintainer

If you'd prefer not to ship `force_include: true` for everyone, the mechanism still lands here and affected users can set the flag themselves — but since `config.yml` ships with the component and is overwritten on update, setting it upstream is what actually fixes the regression for these users without a local-edit-after-every-update workaround.
