### PR TITLE
Allow climate control without a room-temperature sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python bytecode and interpreter caches
+__pycache__/
+*.py[cod]
+
+# Generated diagnostics from the tag dump tool
+development_resources/dump_all/tag_dump_*.txt

--- a/custom_components/orca/climate.py
+++ b/custom_components/orca/climate.py
@@ -70,12 +70,13 @@ class OrcaClimate(OrcaEntity, ClimateEntity):
     def __init__(self, coordinator: OrcaDataUpdateCoordinator, circuit_id: int) -> None:
         """Initialize the climate entity."""
         self._circuit_id = circuit_id
-        super().__init__(coordinator, self._get_unique_id("hc_room_temp"))
+        super().__init__(coordinator, None)
 
         # support for both languages
-        eng_name: str = self.coordinator.data.get(self._get_unique_id("hc_name")).value
+        name_tag = self.coordinator.data.get(self._get_unique_id("hc_name"))
+        eng_name = str(name_tag.value) if name_tag else f"Heating Circuit {circuit_id}"
         if coordinator.config_entry.data.get(CONF_LANGUAGE, LANG_EN) == LANG_SI:
-            self._attr_name = str(CIRCUIT_NAME_MAP_SI[eng_name]).title()
+            self._attr_name = CIRCUIT_NAME_MAP_SI.get(eng_name, eng_name).title()
         else:
             self._attr_name = eng_name
         self._attr_unique_id = (
@@ -182,10 +183,10 @@ class OrcaClimate(OrcaEntity, ClimateEntity):
             return
 
         if val == "off":
-            await self.coordinator.api.set_value_by_id("hc_turned_on", False)
+            await self.coordinator.api.set_value_by_id(self._get_unique_id("hc_turned_on"), False)
         else:
             # Ensure On, then set mode
-            await self.coordinator.api.set_value_by_id("hc_turned_on", True)
-            await self.coordinator.api.set_value_by_id("hc_mode", val)
+            await self.coordinator.api.set_value_by_id(self._get_unique_id("hc_turned_on"), True)
+            await self.coordinator.api.set_value_by_id(self._get_unique_id("hc_mode"), val)
 
         await self.coordinator.async_request_refresh()

--- a/custom_components/orca/config.yml
+++ b/custom_components/orca/config.yml
@@ -180,7 +180,7 @@
     2: "cool"
     3: "auto"
   adjustable:
-    enabled: false
+    enabled: true
   heating_circuit: 1
 
 - tag: 2_Izbira_TIMERJA_MK1
@@ -456,7 +456,7 @@
     2: "cool"
     3: "auto"
   adjustable:
-    enabled: false
+    enabled: true
   heating_circuit: 2
 
 - tag: 2_Izbira_TIMERJA_MK2

--- a/custom_components/orca/entity.py
+++ b/custom_components/orca/entity.py
@@ -17,7 +17,7 @@ class OrcaEntity(CoordinatorEntity[OrcaDataUpdateCoordinator]):
     def __init__(
         self,
         coordinator: OrcaDataUpdateCoordinator,
-        unique_id_: str,  # as defined in config.yml
+        unique_id_: str | None,  # as defined in config.yml
         entity_description=None,
     ) -> None:
         """Initialize the entity."""
@@ -26,24 +26,21 @@ class OrcaEntity(CoordinatorEntity[OrcaDataUpdateCoordinator]):
         if entity_description:
             self.entity_description = entity_description
 
-        # Determine name and unique ID from the coordinator data
-        tag_data = self.coordinator.data[self.unique_id_]
+        if tag_data := self.coordinator.data.get(self.unique_id_):
+            # get language according to setup
+            selected_lang = self.coordinator.config_entry.data.get(CONF_LANGUAGE, LANG_EN)
 
-        # get language according to setup
-        selected_lang = self.coordinator.config_entry.data.get(CONF_LANGUAGE, LANG_EN)
+            if selected_lang == LANG_SI:
+                # Use slovenian entity name
+                self._attr_name = tag_data.config.name.si
+            else:
+                # Use english entity name
+                self._attr_name = tag_data.config.name.en
 
-        if selected_lang == LANG_SI:
-            # Use slovenian entity name
-            self._attr_name = tag_data.config.name.si
-        else:
-            # Use english entity name
-            self._attr_name = tag_data.config.name.en
-
-        # Unique ID must be globally unique. Combine entry_id + API unique_id
-        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{unique_id_}"
+            # Unique ID must be globally unique. Combine entry_id + API unique_id
+            self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{unique_id_}"
+            self._attr_entity_category = self._get_category(tag_data)
         self._attr_has_entity_name = False
-
-        self._attr_entity_category = self._get_category(tag_data)
 
     def _get_category(self, tag_data: OrcaTagValue) -> EntityCategory | None:
         """Determine the category based on config flags."""
@@ -74,4 +71,4 @@ class OrcaEntity(CoordinatorEntity[OrcaDataUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return super().available and self.unique_id_ in self.coordinator.data
+        return super().available and (self.unique_id_ is None or self.unique_id_ in self.coordinator.data)

--- a/custom_components/orca/orca_api.py
+++ b/custom_components/orca/orca_api.py
@@ -50,7 +50,7 @@ CIRCUIT_NAME_MAP_SI = {
     "1. Floor": "1. nadstropje",
     "2. Floor": "2. nadstropje",
     "Attic": "mansarda",
-    "Radiator": "tadiatorji",
+    "Radiator": "radiatorji",
     "Convector": "konvektorji",
     "Heating": "gretje",
     "Cooling": "hlajenje",


### PR DESCRIPTION
Summary

This fixes climate entities not being created when a selected heating circuit has no room-temperature sensor attached.

On some heat pumps, the room-temperature tag returns `-9999` when no sensor is connected. The integration correctly filters that value, but the climate entity previously used that tag as its required base entity. This caused a `KeyError` during setup and prevented the entire climate platform from loading, including other valid heating circuits.

The climate entity is now created from the selected/detected heating circuit rather than requiring the room-temperature sensor value. The room temperature remains optional and is unavailable when no sensor is installed, while target temperature and HVAC controls remain usable.

Changes

- Create Floor/Radiator climate entities from configured heating circuits without requiring a room-temperature value.
- Allow circuit-level climate entities to initialize when their room-temperature tag is absent.
- Use circuit-specific IDs when writing HVAC on/off and mode values.
- Mark the configured heating-circuit mode tags as writable.
- Fix the Slovenian `Radiator` translation typo (`tadiatorji` → `radiatorji`).
- Add `.gitignore` rules for generated Python cache files and tag-dump output.

Notes / follow-up

This is a functional solution for heat pumps without an attached room-temperature sensor, but the current implementation is somewhat provisional.

This implementation was tested on a heat pump without a room-temperature sensor. Climate entity availability, target-temperature control, and HVAC mode selection worked on that system.