### PR TITLE
Support external-input and manual circuit modes

### DIFF
--- a/custom_components/orca/climate.py
+++ b/custom_components/orca/climate.py
@@ -20,11 +20,14 @@ from .coordinator import OrcaDataUpdateCoordinator
 from .entity import OrcaEntity
 from .orca_api import CIRCUIT_NAME_MAP_SI
 
-# Mapping of Orca modes to HA modes
+# Controller-managed modes have no direct HA equivalent, so this mapping is
+# lossy; the API data retains the actual selector value.
 MODE_MAPPING = {
     "auto": HVACMode.HEAT_COOL,
     "cool": HVACMode.COOL,
+    "external_input_id2": HVACMode.HEAT_COOL,
     "heat": HVACMode.HEAT,
+    "manual": HVACMode.HEAT_COOL,
 }
 
 REVERSE_MODE_MAPPING = {

--- a/custom_components/orca/config.yml
+++ b/custom_components/orca/config.yml
@@ -179,6 +179,8 @@
     1: "heat"
     2: "cool"
     3: "auto"
+    4: "external_input_id2"
+    5: "manual"
   adjustable:
     enabled: false
   heating_circuit: 1
@@ -455,6 +457,8 @@
     1: "heat"
     2: "cool"
     3: "auto"
+    4: "external_input_id2"
+    5: "manual"
   adjustable:
     enabled: false
   heating_circuit: 2

--- a/custom_components/orca/orca_api.py
+++ b/custom_components/orca/orca_api.py
@@ -278,7 +278,12 @@ class OrcaApi:
             if processed_value is not None:
                 result.append(OrcaTagValue(tag=tag, value=processed_value, config=config))
             else:
-                _LOGGER.error(f"Failed to convert value \"{raw_val_str}\" to configured type.")
+                _LOGGER.error(
+                    "Failed to convert tag %s value %r to configured type %s.",
+                    tag,
+                    raw_val_str,
+                    config.type,
+                )
 
         return result
 


### PR DESCRIPTION
## Summary

- add the confirmed `external_input_id2` and `manual` selector values for both heating circuits
- represent both controller-managed modes as `HVACMode.HEAT_COOL` because Home Assistant has no direct equivalents
- improve conversion errors with the tag, raw value, and configured type using lazy logger formatting

## Why

The mode enums for `2_Rezim_MK1` and `2_Rezim_MK2` only covered values 1–3. Controller readbacks confirmed that values 4 and 5 represent external input ID2 and manual commutation. Without these entries, valid selector values failed conversion.

The climate mapping is intentionally lossy: Home Assistant displays these controller-managed selectors as `HEAT_COOL`, while the API data retains the actual selector value. Reverse mapping remains unchanged, so Home Assistant continues writing only the established heat, cool, and auto values.

## Validation

- Python syntax compilation
- YAML parsing and exact value-map assertions for both affected tags
- focused raw-value conversion checks for values 4 and 5
- climate mapping and unchanged reverse-mapping assertions
- lazy logger formatting assertion
- line-ending-aware `git diff --check`

The repository has no automated unit-test framework, so no new test framework was introduced.
