### PR TITLE
Skip empty Orca tag values

### DIFF
--- a/custom_components/orca/orca_api.py
+++ b/custom_components/orca/orca_api.py
@@ -270,15 +270,17 @@ class OrcaApi:
         for tag, raw_val_str in parsed_data.items():
             config = self._config_by_tags[tag]
 
-            # Check for non-existent sensors
-            if raw_val_str == "-9999":
+            # Check for unavailable sensor values
+            if raw_val_str in ("", "-9999"):
                 continue
 
             processed_value = self._convert_read_value(raw_val_str, config)
             if processed_value is not None:
                 result.append(OrcaTagValue(tag=tag, value=processed_value, config=config))
             else:
-                _LOGGER.error(f"Failed to convert value \"{raw_val_str}\" to configured type.")
+                _LOGGER.error(
+                    "Failed to convert value tag: %s raw_value: %r", tag, raw_val_str
+                )
 
         return result
 


### PR DESCRIPTION
## What changed

- skip empty tag values before type conversion, matching the existing `-9999` handling
- include the affected tag and raw value when a non-empty value cannot be converted

## Why

The heat pump can transiently return an empty value with `S_OK`. Empty strings currently reach the type converter, return `None`, and produce a generic error without identifying the affected tag. Skipping these transient values keeps the last entity state available through the coordinator while avoiding noisy conversion errors.

## Validation

- `git diff --check`
- Python compilation of `custom_components/orca/orca_api.py`
- isolated regression harness covering empty, `-9999`, valid float/boolean/multimode, and malformed non-empty values
